### PR TITLE
Map ./assets/shared to root path

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,8 @@ function runServer(opts) {
   staticPaths.forEach(function(path) {
     server.use('/assets', express.static(opts.dir + path));
   });
+  
+  server.use('/', express.static(opts.dir + '/assets/shared'));
 
   server.get('*', function(req, res) {
     res.send(opts.template);


### PR DESCRIPTION
Since all the files from `assets/shared` are always copied to all builds, it would be convenient directly reference such assets without using `require`

https://github.com/reapp/reapp/issues/75
